### PR TITLE
frontend: ビルドが失敗する問題の解消

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -22,11 +22,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src"],
-  "baseUrl": ".",
-  "paths": {
-    "@/*": ["./src/*"]
-  }
+  "include": ["src"]
 }


### PR DESCRIPTION
`tsconfig.app.json`でのエイリアスの設定を書く場所が間違っていて、正しくエイリアスを読み込めていないことが原因でした。