### PR TITLE
backend:settings.pyで使用するアプリケーションフォルダの登録

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "app"
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
アプリケーションフォルダを認識させるためにsettings.pyのINSTALLED_APPSに"app"を追加しました。